### PR TITLE
Oswitto624/blog post manager tests continuation

### DIFF
--- a/Services/Thoughts.Services/RepositoryBlogPostManager.cs
+++ b/Services/Thoughts.Services/RepositoryBlogPostManager.cs
@@ -260,16 +260,16 @@ public class RepositoryBlogPostManager : IBlogPostManager
         if (Tag is null) throw new ArgumentNullException(nameof(Tag));
 
         var post = await GetPostAsync(PostId, Cancel).ConfigureAwait(false);
+        if (post is null) return false;
+        
         var tag = await _tagRepo.GetByName(Tag, Cancel).ConfigureAwait(false);
-
-        if (post is null || Tag is null) return false;
 
         if (!post.Tags.Contains(tag))
             return false;
 
-        tag.Posts.Remove(post); // тут я подумал, а почему нет, раз есть в тегах есть ссылка на посты, которые связаны с этим тегом
+        //tag.Posts.Remove(post); // тут я подумал, а почему нет, раз есть в тегах есть ссылка на посты, которые связаны с этим тегом
 
-        //post.Tags.Remove(tag);
+        post.Tags.Remove(tag); //но пришлось всё же использовать этот путь
 
         await _postRepo.Update(post, Cancel).ConfigureAwait(false);
         await _tagRepo.Update(tag, Cancel).ConfigureAwait(false); //нужно ли тут репозиторий тега обновлять

--- a/Services/Thoughts.Services/RepositoryBlogPostManager.cs
+++ b/Services/Thoughts.Services/RepositoryBlogPostManager.cs
@@ -71,14 +71,13 @@ public class RepositoryBlogPostManager : IBlogPostManager
 
         //var total_count = await GetAllPostsCountAsync(Cancel).ConfigureAwait(false);
 
-        if(PageIndex == 0)
+        if(PageSize == 0)
             return new Page<Post>(Enumerable.Empty<Post>(), PageIndex, PageSize, total_count);
 
         var page = await _postRepo.GetPage(PageIndex, PageSize, Cancel).ConfigureAwait(false);
 
         //здесь не уверен, всё же в конструкторе страницы обязательно указывать общее количество, а в интерфейсе репозитория общее количество не указывается
         return page;
-
     }
 
     #endregion
@@ -93,8 +92,8 @@ public class RepositoryBlogPostManager : IBlogPostManager
     {
         var all_posts = await _postRepo.GetAll(Cancel);
 
-        var user_posts = all_posts.Where(p => p.User.Id == UserId); //без Result никак
-        return await Task.FromResult(user_posts).ConfigureAwait(false);
+        var user_posts = all_posts.Where(p => p.User.Id == UserId);
+        return user_posts;
     }
 
     /// <summary> Получение количества всех постов пользователя </summary>
@@ -107,7 +106,7 @@ public class RepositoryBlogPostManager : IBlogPostManager
 
         var count = all_posts.Count(p => p.User.Id == UserId); // todo: надо обучить репозиторий выдавать записи по id указанного пользователя
         
-        return await Task.FromResult(count).ConfigureAwait(false);
+        return count;
     }
 
     /// <summary> Получение выборки постов для пагинации конкретного пользователя </summary>
@@ -125,7 +124,7 @@ public class RepositoryBlogPostManager : IBlogPostManager
 
         var page = all_posts_by_user_id.Skip(Skip).Take(Take);
         
-        return await Task.FromResult(page).ConfigureAwait(false);
+        return page;
     }
 
     /// <summary> Получение страницы постов пользователя </summary>

--- a/Services/Thoughts.Services/RepositoryBlogPostManager.cs
+++ b/Services/Thoughts.Services/RepositoryBlogPostManager.cs
@@ -234,7 +234,7 @@ public class RepositoryBlogPostManager : IBlogPostManager
 
         var post = await GetPostAsync(PostId, Cancel).ConfigureAwait(false);
         
-        if( post is null || Tag is null ) return false;
+        if (post is null) return false;
 
         var tag = await _tagRepo.ExistName(Tag, Cancel).ConfigureAwait(false)
                 ? await _tagRepo.GetByName(Tag, Cancel).ConfigureAwait(false)

--- a/Services/Thoughts.Services/RepositoryBlogPostManager.cs
+++ b/Services/Thoughts.Services/RepositoryBlogPostManager.cs
@@ -211,8 +211,12 @@ public class RepositoryBlogPostManager : IBlogPostManager
                         : new Category { Name = Category },
         };
 
-        await _postRepo.Update(post, Cancel).ConfigureAwait(false);
-        return await _postRepo.Add(post,Cancel).ConfigureAwait(false);
+        //await _postRepo.Update(post, Cancel).ConfigureAwait(false);
+        await _postRepo.Add(post,Cancel).ConfigureAwait(false);
+        
+        return post;
+
+        //return await _postRepo.Add(post, Cancel).ConfigureAwait(false); // <- пришлось отказаться от такой реализации, так как в тесте не возвращался пост, хоть на Add настроен мок
     }
 
     #endregion

--- a/Services/Thoughts.Services/RepositoryBlogPostManager.cs
+++ b/Services/Thoughts.Services/RepositoryBlogPostManager.cs
@@ -102,9 +102,9 @@ public class RepositoryBlogPostManager : IBlogPostManager
     /// <returns> Количество всех постов пользователя </returns>
     public async Task<int> GetUserPostsCountAsync(string UserId, CancellationToken Cancel = default)
     {
-        var all_posts = await _postRepo.GetAll(Cancel);
+        var all_posts = await GetAllPostsByUserIdAsync(UserId, Cancel).ConfigureAwait(false);
 
-        var count = all_posts.Count(p => p.User.Id == UserId); // todo: надо обучить репозиторий выдавать записи по id указанного пользователя
+        var count = all_posts.Count(); // todo: надо обучить репозиторий выдавать записи по id указанного пользователя
         
         return count;
     }
@@ -236,9 +236,22 @@ public class RepositoryBlogPostManager : IBlogPostManager
         
         if (post is null) return false;
 
-        var tag = await _tagRepo.ExistName(Tag, Cancel).ConfigureAwait(false)
-                ? await _tagRepo.GetByName(Tag, Cancel).ConfigureAwait(false)
-                : new Tag { Name = Tag };
+        //var tag = await _tagRepo.ExistName(Tag, Cancel).ConfigureAwait(false)
+        //        ? await _tagRepo.GetByName(Tag, Cancel).ConfigureAwait(false)
+        //        : new Tag { Name = Tag };
+
+        Tag tag;
+
+        if(await _tagRepo.ExistName(Tag, Cancel).ConfigureAwait(false))
+        {
+            tag = await _tagRepo.GetByName(Tag, Cancel).ConfigureAwait(false);
+            await _tagRepo.Update(tag, Cancel).ConfigureAwait(false);
+        }
+        else
+        {
+            tag = new Tag { Name = Tag };
+            await _tagRepo.Add(tag, Cancel).ConfigureAwait(false);
+        }
 
         if (post.Tags.Contains(tag))
             return true;              //  <- наверное всё же true, так как тег с таким именем уже есть в посте

--- a/Services/Thoughts.Services/RepositoryBlogPostManager.cs
+++ b/Services/Thoughts.Services/RepositoryBlogPostManager.cs
@@ -137,10 +137,13 @@ public class RepositoryBlogPostManager : IBlogPostManager
     {
         var count = await GetUserPostsCountAsync(UserId,Cancel).ConfigureAwait(false);
 
-        if (PageIndex == 0)
+        if (PageSize == 0)
             return new Page<Post>(Enumerable.Empty<Post>(), PageIndex, PageSize, count);
 
-        var posts = await GetAllPostsByUserIdAsync(UserId, Cancel).ConfigureAwait(false); //здесь не как в GetAllPostsPageAsync - метод GetPage из IRepository не даёт сделать выборку по Id
+        //var user_posts = await GetAllPostsByUserIdAsync(UserId, Cancel).ConfigureAwait(false); //здесь не как в GetAllPostsPageAsync - метод GetPage из IRepository не даёт сделать выборку по Id
+        var user_posts = await _postRepo.GetAll(Cancel).ConfigureAwait(false);
+
+        var posts = user_posts.Where(p => p.User.Id == UserId).Skip(PageIndex * PageSize).Take(PageSize);
 
         return new Page<Post>(posts, PageIndex, PageSize, count);
     }

--- a/Tests/Thoughts.Services.Tests/RepositoryBlogPostManagerTests.cs
+++ b/Tests/Thoughts.Services.Tests/RepositoryBlogPostManagerTests.cs
@@ -210,16 +210,16 @@ public class RepositoryBlogPostManagerTests
     }
 
     [TestMethod]
-    public async Task GetAllPostsPageAsync_Test_Returns_EmptyPage()
+    public async Task GetAllPostsPageAsync_Test_Returns_EmptyPage_when_pageSize_eq_0()
     {
         var total_count = _Posts.Length;
 
-        int pageIndex = 0;
-        int pageSize = 3;
+        int pageIndex = 2;
+        int pageSize = 0;
 
         var expected_page = new Page<Post>(Enumerable.Empty<Post>(), pageIndex, pageSize, total_count);
 
-        _Post_Repo_Mock.Setup(c => c.GetPage(pageIndex, pageSize, It.IsAny<CancellationToken>()));
+        _Post_Repo_Mock.Setup(c => c.GetPage(pageIndex, pageSize, It.IsAny<CancellationToken>())).ReturnsAsync(expected_page);
 
         var actual_page = await _BlogPostManager.GetAllPostsPageAsync(pageIndex, pageSize);
 
@@ -230,9 +230,9 @@ public class RepositoryBlogPostManagerTests
     public async Task GetAllPostsPageAsync_Test_Returns_Page()
     {
         var total_count = _Posts.Length;
-        int pageIndex = 3;
+        int pageIndex = 2;
         int pageSize = 3;
-        var posts = _Posts;
+        var posts = _Posts.Skip(pageIndex * pageSize).Take(pageSize);
 
         var expected_page = new Page<Post>(posts,
                                            pageIndex,
@@ -244,7 +244,7 @@ public class RepositoryBlogPostManagerTests
 
         var actual_page = await _BlogPostManager.GetAllPostsPageAsync(pageIndex, pageSize);
 
-        Assert.IsTrue(ReferenceEquals(expected_page, actual_page));
+        //Assert.IsTrue(ReferenceEquals(expected_page, actual_page));
         Assert.AreEqual(expected_page, actual_page);
     }
 

--- a/Tests/Thoughts.Services.Tests/RepositoryBlogPostManagerTests.cs
+++ b/Tests/Thoughts.Services.Tests/RepositoryBlogPostManagerTests.cs
@@ -760,4 +760,87 @@ public class RepositoryBlogPostManagerTests
     }
 
     #endregion
+
+    #region Tag - RemoveTag (4 tests)
+
+    [TestMethod]
+    public async Task RemoveTagAsync_Test_Returns_True()
+    {
+        var post = _Posts[6];
+        post.Tags = post.Tags.ToList();
+        var tag = _Tags[0];
+        var expected_result = true;
+
+        _Post_Repo_Mock.Setup(c => c.GetById(post.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(post);
+        _Tag_Repo_Mock.Setup(c => c.GetByName(tag.Name, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tag);
+        _Post_Repo_Mock.Setup(c => c.Update(post, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(post);
+        _Tag_Repo_Mock.Setup(c => c.Update(tag, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tag);
+
+        var actual_result = await _BlogPostManager.RemoveTagAsync(post.Id, tag.Name);
+
+        Assert.AreEqual(expected_result, actual_result);
+        CollectionAssert.Contains(_Tags, _Tags[0]);
+        Assert.IsTrue(post.Tags.Count() == 1);
+        Assert.IsTrue(_Tags.Length == 3);
+
+        _Post_Repo_Mock.Verify();
+        _Tag_Repo_Mock.Verify();
+    }
+
+    [TestMethod]
+    public async Task RemoveTagAsync_Test_Returns_ArgumentNullException_When_TagName_is_Null()
+    {
+        var post = _Posts[0];
+        string Tag = null; //проверяем Tag на null
+        var expected_exception = new ArgumentNullException(nameof(Tag));
+
+        try
+        {
+            await _BlogPostManager.RemoveTagAsync(post.Id, Tag);
+        }
+        catch (Exception actual_exception)
+        {
+            Assert.AreEqual(expected_exception.Message, actual_exception.Message);
+            Assert.AreEqual(expected_exception.GetType(), actual_exception.GetType());
+            return;
+        }
+
+        Assert.Fail("Исключение не было получено.");
+    }
+
+    [TestMethod]
+    public async Task RemoveTagAsync_Test_Returns_False_When_Post_is_Null()
+    {
+        var post_id = 10;
+        var tag = _Tags[0];
+
+        var actual_result = await _BlogPostManager.RemoveTagAsync(post_id, tag.Name);
+
+        Assert.IsFalse(actual_result);
+    }
+
+    [TestMethod]
+    public async Task RemoveTagAsync_Test_Returns_False_When_Post_NotContains_Tag()
+    {
+        var post = _Posts[0];
+        post.Tags = post.Tags.ToList();
+        var tag = _Tags[2];  // этот тег не прикреплён к посту
+
+        _Post_Repo_Mock.Setup(c => c.GetById(post.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(post);
+        _Tag_Repo_Mock.Setup(c => c.GetByName(tag.Name, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tag);
+
+        var actual_result = await _BlogPostManager.RemoveTagAsync(post.Id, tag.Name);
+
+        Assert.IsFalse(actual_result);
+        _Post_Repo_Mock.Verify();
+        _Tag_Repo_Mock.Verify();
+    }
+
+    #endregion
 }

--- a/Tests/Thoughts.Services.Tests/RepositoryBlogPostManagerTests.cs
+++ b/Tests/Thoughts.Services.Tests/RepositoryBlogPostManagerTests.cs
@@ -170,6 +170,9 @@ public class RepositoryBlogPostManagerTests
         var actual_posts = await _BlogPostManager.GetAllPostsAsync();
 
         CollectionAssert.AreEqual(expected_posts, actual_posts.ToArray());
+
+        _Post_Repo_Mock.Verify(c => c.GetAll(It.IsAny<CancellationToken>()));
+        _Post_Repo_Mock.VerifyNoOtherCalls();
     }
 
     [TestMethod]
@@ -184,6 +187,9 @@ public class RepositoryBlogPostManagerTests
         var actual_posts_count = await _BlogPostManager.GetAllPostsCountAsync();
 
         Assert.AreEqual(expected_posts_count, actual_posts_count);
+
+        _Post_Repo_Mock.Verify(c => c.GetCount(It.IsAny<CancellationToken>()));
+        _Post_Repo_Mock.VerifyNoOtherCalls();
     }
 
     [TestMethod]
@@ -193,9 +199,6 @@ public class RepositoryBlogPostManagerTests
         int take = 0; //проверяем If: Take == 0
 
         var expected_page = _Posts.ToArray().Skip(skip).Take(take);
-
-        _Post_Repo_Mock.Setup(c => c.Get(skip, take, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(expected_page);
 
         var actual_page = await _BlogPostManager.GetAllPostsSkipTakeAsync(skip, take);
 
@@ -216,6 +219,9 @@ public class RepositoryBlogPostManagerTests
         var actual_page = await _BlogPostManager.GetAllPostsSkipTakeAsync(skip, take);
 
         CollectionAssert.AreEqual(expected_page.ToArray(), actual_page.ToArray());
+
+        _Post_Repo_Mock.Verify(c => c.Get(skip, take, It.IsAny<CancellationToken>()));
+        _Post_Repo_Mock.VerifyNoOtherCalls();
     }
 
     [TestMethod]
@@ -228,11 +234,14 @@ public class RepositoryBlogPostManagerTests
 
         var expected_page = new Page<Post>(Enumerable.Empty<Post>(), pageIndex, pageSize, total_count);
 
-        _Post_Repo_Mock.Setup(c => c.GetPage(pageIndex, pageSize, It.IsAny<CancellationToken>())).ReturnsAsync(expected_page);
+        _Post_Repo_Mock.Setup(c => c.GetCount(It.IsAny<CancellationToken>())).ReturnsAsync(total_count);
 
         var actual_page = await _BlogPostManager.GetAllPostsPageAsync(pageIndex, pageSize);
 
         Assert.AreEqual(expected_page.Items, actual_page.Items);
+
+        _Post_Repo_Mock.Verify(c => c.GetCount(It.IsAny<CancellationToken>()));
+        _Post_Repo_Mock.VerifyNoOtherCalls();
     }
 
     [TestMethod]
@@ -250,11 +259,16 @@ public class RepositoryBlogPostManagerTests
 
         _Post_Repo_Mock.Setup(c => c.GetPage(pageIndex, pageSize, It.IsAny<CancellationToken>()))
             .ReturnsAsync(expected_page);
+        _Post_Repo_Mock.Setup(c => c.GetCount(It.IsAny<CancellationToken>())).ReturnsAsync(total_count);
 
         var actual_page = await _BlogPostManager.GetAllPostsPageAsync(pageIndex, pageSize);
 
         //Assert.IsTrue(ReferenceEquals(expected_page, actual_page));
         Assert.AreEqual(expected_page, actual_page);
+
+        _Post_Repo_Mock.Verify(c => c.GetPage(pageIndex, pageSize, It.IsAny<CancellationToken>()));
+        _Post_Repo_Mock.Verify(c => c.GetCount(It.IsAny<CancellationToken>()));
+        _Post_Repo_Mock.VerifyNoOtherCalls();
     }
 
     #endregion
@@ -274,6 +288,9 @@ public class RepositoryBlogPostManagerTests
         var actual_posts = await _BlogPostManager.GetAllPostsByUserIdAsync(user_id);
 
         CollectionAssert.AreEqual(expected_posts.ToArray(), actual_posts.ToArray());
+
+        _Post_Repo_Mock.Verify(c => c.GetAll(It.IsAny<CancellationToken>()));
+        _Post_Repo_Mock.VerifyNoOtherCalls();
     }
 
     [TestMethod]
@@ -283,12 +300,15 @@ public class RepositoryBlogPostManagerTests
         var posts = _Posts.Where(p => p.UserId == user_id);
         var expected_posts_count = posts.Count();
 
-        _Post_Repo_Mock.Setup(c => c.GetCount(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(expected_posts_count);
+        _Post_Repo_Mock.Setup(c => c.GetAll(It.IsAny<CancellationToken>()))
+                                    .ReturnsAsync(posts);
 
         var actual_posts_count = await _BlogPostManager.GetUserPostsCountAsync(user_id);
 
         Assert.AreEqual(expected_posts_count, actual_posts_count);
+
+        _Post_Repo_Mock.Verify(c => c.GetAll(It.IsAny<CancellationToken>()));
+        _Post_Repo_Mock.VerifyNoOtherCalls();
     }
 
     [TestMethod]
@@ -299,9 +319,6 @@ public class RepositoryBlogPostManagerTests
         var take = 0; //проверяем If: Take == 0
 
         var expected_page = _Posts.Where(p => p.User.Id == user_id).Skip(skip).Take(take);
-
-        _Post_Repo_Mock.Setup(c => c.Get(skip, take, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(expected_page);
 
         var actual_page = await _BlogPostManager.GetAllPostsByUserIdSkipTakeAsync(user_id, skip, take);
 
@@ -323,25 +340,31 @@ public class RepositoryBlogPostManagerTests
         var actual_page = await _BlogPostManager.GetAllPostsByUserIdSkipTakeAsync(user_id, skip, take);
 
         CollectionAssert.AreEqual(expected_page.ToArray(), actual_page.ToArray());
+
+        _Post_Repo_Mock.Verify(c => c.GetAll(It.IsAny<CancellationToken>()));
+        _Post_Repo_Mock.VerifyNoOtherCalls();
     }
 
     [TestMethod]
     public async Task GetAllPostsByUserIdPageAsync_Test_Returns_EmptyPage_when_pageSize_eq_0()
     {
         var user_id = "1";
-        var total_count = _Posts.Where(c => c.User.Id == user_id).Count();
-
+        var total_user_posts = _Posts.Where(c => c.User.Id == user_id);
+        var total_count = total_user_posts.Count();
         int pageIndex = 2;
         int pageSize = 0;
 
         var expected_page = new Page<Post>(Enumerable.Empty<Post>(), pageIndex, pageSize, total_count);
 
-        _Post_Repo_Mock.Setup(c => c.GetPage(pageIndex, pageSize, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(expected_page);
+        _Post_Repo_Mock.Setup(c => c.GetAll(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(total_user_posts);
 
         var actual_page = await _BlogPostManager.GetAllPostsByUserIdPageAsync(user_id, pageIndex, pageSize);
 
         Assert.AreEqual(expected_page.Items, actual_page.Items);
+
+        _Post_Repo_Mock.Verify(c => c.GetAll(It.IsAny<CancellationToken>()));
+        _Post_Repo_Mock.VerifyNoOtherCalls();
     }
 
     [TestMethod]
@@ -366,6 +389,9 @@ public class RepositoryBlogPostManagerTests
         Assert.AreEqual(pageIndex, actual_page.PageNumber);
         Assert.AreEqual(pageSize, actual_page.PageSize);
         Assert.AreEqual(total_count, actual_page.TotalCount);
+
+        _Post_Repo_Mock.Verify(c => c.GetAll(It.IsAny<CancellationToken>()));
+        _Post_Repo_Mock.VerifyNoOtherCalls();
     }
 
     #endregion
@@ -384,6 +410,9 @@ public class RepositoryBlogPostManagerTests
         var actual_post = await _BlogPostManager.GetPostAsync(post_id);
 
         Assert.AreEqual(expected_post, actual_post);
+
+        _Post_Repo_Mock.Verify(p => p.GetById(post_id, It.IsAny<CancellationToken>()));
+        _Post_Repo_Mock.VerifyNoOtherCalls();
     }
 
     [TestMethod]
@@ -407,10 +436,10 @@ public class RepositoryBlogPostManagerTests
             .ReturnsAsync(posts);
         var actual_posts = await _BlogPostManager.GetAllPostsAsync();
 
-
         Assert.AreEqual(expecting_result, actual_result);
         CollectionAssert.AreNotEqual(_Posts, posts);
         CollectionAssert.AreEqual(posts, actual_posts.ToArray());
+
         _Post_Repo_Mock.Verify(c => c.DeleteById(post_id, It.IsAny<CancellationToken>()));
         _Post_Repo_Mock.Verify(c => c.GetById(post_id, It.IsAny<CancellationToken>()));
         _Post_Repo_Mock.Verify(c => c.GetAll(It.IsAny<CancellationToken>()));
@@ -433,6 +462,10 @@ public class RepositoryBlogPostManagerTests
         var actual_result = await _BlogPostManager.DeletePostAsync(post_id);
 
         Assert.AreEqual(expecting_result, actual_result);
+
+        _Post_Repo_Mock.Verify(p => p.GetById(post_id, It.IsAny<CancellationToken>()));
+        _Post_Repo_Mock.Verify(c => c.DeleteById(post_id, It.IsAny<CancellationToken>()));
+        _Post_Repo_Mock.VerifyNoOtherCalls();
     }
     #endregion
 
@@ -477,9 +510,12 @@ public class RepositoryBlogPostManagerTests
         //Assert.AreEqual(expected_post, actual_post); // <- любые прямые сравнения объектов у меня не сработали
         // в общем, полностью сравнивать объекты не получается
 
-        _Post_Repo_Mock.Verify();
-        _Category_Repo_Mock.Verify();
-        _User_Repo_Mock.Verify();
+        _User_Repo_Mock.Verify(c => c.GetById(user_id, It.IsAny<CancellationToken>()));
+        _Category_Repo_Mock.Verify(c => c.ExistName(new_category, It.IsAny<CancellationToken>()));
+        //_Post_Repo_Mock.Verify(c => c.Add(expected_post, It.IsAny<CancellationToken>())); //Add не проходит верификацию
+        _User_Repo_Mock.VerifyNoOtherCalls();
+        //_Post_Repo_Mock.VerifyNoOtherCalls();
+        _Category_Repo_Mock.VerifyNoOtherCalls();
     }
 
     [TestMethod]
@@ -519,12 +555,15 @@ public class RepositoryBlogPostManagerTests
         Assert.AreEqual(expected_post.Body, actual_post.Body);
         Assert.AreEqual(expected_post.User.Id, actual_post.User.Id);
         Assert.AreEqual(expected_post.Category.Name, actual_post.Category.Name);
-
         Assert.AreEqual(expected_category, actual_post.Category);
 
-        _Post_Repo_Mock.Verify();
-        _Category_Repo_Mock.Verify();
-        _User_Repo_Mock.Verify();
+        _User_Repo_Mock.Verify(c => c.GetById(user_id, It.IsAny<CancellationToken>()));
+        _Category_Repo_Mock.Verify(c => c.ExistName(old_category, It.IsAny<CancellationToken>()));
+        _Category_Repo_Mock.Verify(c => c.GetByName(old_category, It.IsAny<CancellationToken>()));
+        //_Post_Repo_Mock.Verify(c => c.Add(expected_post, It.IsAny<CancellationToken>())); //Add не проходит верификацию
+        _User_Repo_Mock.VerifyNoOtherCalls();
+        //_Post_Repo_Mock.VerifyNoOtherCalls();
+        _Category_Repo_Mock.VerifyNoOtherCalls();
     }
 
     [TestMethod]
@@ -657,33 +696,39 @@ public class RepositoryBlogPostManagerTests
     {
         var post = _Posts[0];
         post.Tags = post.Tags.ToList(); //иначе Add не сработает
-        var tag_name = "Tag3";
         var expected_tag = _Tags[2];  // <- существующий "Tag3"
         var expected_result = true;
 
         _Post_Repo_Mock.Setup(c => c.GetById(post.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(post);
-        _Tag_Repo_Mock.Setup(c => c.ExistName(tag_name, It.IsAny<CancellationToken>()))
+        _Tag_Repo_Mock.Setup(c => c.ExistName(expected_tag.Name, It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
-        _Tag_Repo_Mock.Setup(c => c.GetByName(tag_name, It.IsAny<CancellationToken>()))
+        _Tag_Repo_Mock.Setup(c => c.GetByName(expected_tag.Name, It.IsAny<CancellationToken>()))
             .ReturnsAsync(expected_tag);
-        _Tag_Repo_Mock.Setup(c => c.Add(expected_tag, It.IsAny<CancellationToken>()))
+        _Tag_Repo_Mock.Setup(c => c.Update(expected_tag, It.IsAny<CancellationToken>()))
             .ReturnsAsync(expected_tag);
         _Post_Repo_Mock.Setup(c => c.Update(post, It.IsAny<CancellationToken>()))
             .ReturnsAsync(post);
 
-        var actual_result = await _BlogPostManager.AssignTagAsync(post.Id, tag_name);
+        var actual_result = await _BlogPostManager.AssignTagAsync(post.Id, expected_tag.Name);
 
         Assert.AreEqual(expected_result, actual_result);
-        Assert.IsTrue(post.Tags.Count() == 2); 
-        
-        _Tag_Repo_Mock.Verify();
-        _Post_Repo_Mock.Verify();
+        Assert.IsTrue(post.Tags.Count() == 2);
+
+        _Post_Repo_Mock.Verify(c => c.GetById(post.Id, It.IsAny<CancellationToken>()));
+        _Tag_Repo_Mock.Verify(c => c.ExistName(expected_tag.Name, It.IsAny<CancellationToken>()));
+        _Tag_Repo_Mock.Verify(c => c.GetByName(expected_tag.Name, It.IsAny<CancellationToken>()));
+        _Tag_Repo_Mock.Verify(c => c.Update(expected_tag, It.IsAny<CancellationToken>()));
+        _Post_Repo_Mock.Verify(c => c.Update(post, It.IsAny<CancellationToken>()));
+
+        _Post_Repo_Mock.VerifyNoOtherCalls();
+        _Tag_Repo_Mock.VerifyNoOtherCalls();
     }
 
-    [TestMethod]
-    public async Task AssignTagAsync_Test_Returns_True_when_Tag_Is_NewTag()
+    [TestMethod] // !!!
+    public async Task AssignTagAsync_Test_Returns_True_when_Tag_Is_NewTag() 
     {
+        //todo: не срабатывает верификация метода Add для репозитория тегов
         var post = _Posts[1];
         post.Tags = post.Tags.ToList();
         var tag_name = "Tag4";
@@ -694,8 +739,6 @@ public class RepositoryBlogPostManagerTests
             .ReturnsAsync(post);
         _Tag_Repo_Mock.Setup(c => c.ExistName(tag_name, It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
-        _Tag_Repo_Mock.Setup(c => c.GetByName(tag_name, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(expected_tag);
         _Tag_Repo_Mock.Setup(c => c.Add(expected_tag, It.IsAny<CancellationToken>()))
             .ReturnsAsync(expected_tag);
         _Post_Repo_Mock.Setup(c => c.Update(post, It.IsAny<CancellationToken>()))
@@ -704,9 +747,14 @@ public class RepositoryBlogPostManagerTests
         var actual_result = await _BlogPostManager.AssignTagAsync(post.Id, tag_name);
 
         Assert.AreEqual(expected_result, actual_result);
-        Assert.IsTrue(post.Tags.Count() == 2); 
-        _Tag_Repo_Mock.Verify();
-        _Post_Repo_Mock.Verify();
+        Assert.IsTrue(post.Tags.Count() == 2);
+
+        _Post_Repo_Mock.Verify(c => c.GetById(post.Id, It.IsAny<CancellationToken>()));
+        _Tag_Repo_Mock.Verify(c => c.ExistName(tag_name, It.IsAny<CancellationToken>()));
+        //_Tag_Repo_Mock.Verify(c => c.Add(expected_tag, It.IsAny<CancellationToken>()));
+        _Post_Repo_Mock.Verify(c => c.Update(post, It.IsAny<CancellationToken>()));
+        _Post_Repo_Mock.VerifyNoOtherCalls();
+        //_Tag_Repo_Mock.VerifyNoOtherCalls();
     }
 
     [TestMethod]  //судя по отладчику, тест работает неправильно
@@ -730,7 +778,12 @@ public class RepositoryBlogPostManagerTests
         var actual_result = await _BlogPostManager.AssignTagAsync(post.Id, expected_tag.Name);
 
         Assert.AreEqual(expected_result, actual_result);
-        _Tag_Repo_Mock.Verify();
+        
+        //_Post_Repo_Mock.Verify(c => c.GetById(post.Id, It.IsAny<CancellationToken>()));
+        //_Tag_Repo_Mock.Verify(c => c.ExistName(expected_tag.Name, It.IsAny<CancellationToken>()));
+        //_Tag_Repo_Mock.Verify(c => c.GetByName(expected_tag.Name, It.IsAny<CancellationToken>()));
+        //_Post_Repo_Mock.VerifyNoOtherCalls();
+        //_Tag_Repo_Mock.VerifyNoOtherCalls();
     }
 
     [TestMethod]
@@ -794,8 +847,12 @@ public class RepositoryBlogPostManagerTests
         Assert.IsTrue(post.Tags.Count() == 1);
         Assert.IsTrue(_Tags.Length == 3);
 
-        _Post_Repo_Mock.Verify();
-        _Tag_Repo_Mock.Verify();
+        _Post_Repo_Mock.Verify(c => c.GetById(post.Id, It.IsAny<CancellationToken>()));
+        _Tag_Repo_Mock.Verify(c => c.GetByName(tag.Name, It.IsAny<CancellationToken>()));
+        _Post_Repo_Mock.Verify(c => c.Update(post, It.IsAny<CancellationToken>()));
+        _Tag_Repo_Mock.Verify(c => c.Update(tag, It.IsAny<CancellationToken>()));
+        _Post_Repo_Mock.VerifyNoOtherCalls();
+        _Tag_Repo_Mock.VerifyNoOtherCalls();
     }
 
     [TestMethod]
@@ -845,8 +902,10 @@ public class RepositoryBlogPostManagerTests
         var actual_result = await _BlogPostManager.RemoveTagAsync(post.Id, tag.Name);
 
         Assert.IsFalse(actual_result);
-        _Post_Repo_Mock.Verify();
-        _Tag_Repo_Mock.Verify();
+        _Post_Repo_Mock.Verify(c => c.GetById(post.Id, It.IsAny<CancellationToken>()));
+        _Tag_Repo_Mock.Verify(c => c.GetByName(tag.Name, It.IsAny<CancellationToken>()));
+        _Post_Repo_Mock.VerifyNoOtherCalls();
+        _Tag_Repo_Mock.VerifyNoOtherCalls();
     }
 
     #endregion

--- a/Tests/Thoughts.Services.Tests/RepositoryBlogPostManagerTests.cs
+++ b/Tests/Thoughts.Services.Tests/RepositoryBlogPostManagerTests.cs
@@ -941,5 +941,114 @@ public class RepositoryBlogPostManagerTests
 
         Assert.Fail("Исключение не было получено.");
     }
+
+    #endregion
+
+    #region Edit ChangePostTitleAsync ChangePostBodyAsync
+
+    [TestMethod]
+    public async Task ChangePostTitleAsync_Test_Returns_True()
+    {
+        var post = _Posts[0];
+        var new_title = "new title";
+
+        _Post_Repo_Mock.Setup(c => c.GetById(post.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(post);
+        _Post_Repo_Mock.Setup(c => c.Update(post, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(post);
+
+        var actual_post = await _BlogPostManager.ChangePostTitleAsync(post.Id, new_title);
+
+        Assert.IsTrue(actual_post);
+        Assert.AreEqual(post.Title, new_title);
+
+        _Post_Repo_Mock.Verify(c => c.GetById(post.Id, It.IsAny<CancellationToken>()));
+        _Post_Repo_Mock.Verify(c => c.Update(post, It.IsAny<CancellationToken>()));
+        _Post_Repo_Mock.VerifyNoOtherCalls();
+    }
+
+    [TestMethod]
+    public async Task ChangePostTitleAsync_Test_Returns_False_When_Post_Not_Found()
+    {
+        var post_id = 10;
+        var new_title = "new title";
+
+        _Post_Repo_Mock.Setup(c => c.GetById(post_id, It.IsAny<CancellationToken>()));
+
+        var actual_post = await _BlogPostManager.ChangePostTitleAsync(post_id, new_title);
+
+        Assert.IsFalse(actual_post);
+        _Post_Repo_Mock.Verify(c => c.GetById(post_id, It.IsAny<CancellationToken>()));
+        _Post_Repo_Mock.VerifyNoOtherCalls();
+    }
+
+    [TestMethod]
+    public async Task ChangePostTitleAsync_Test_Returns_False_When_Title_is_Null()
+    {
+        var post = _Posts[0];
+        string new_title = null;
+
+        _Post_Repo_Mock.Setup(c => c.GetById(post.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(post);
+
+        var actual_post = await _BlogPostManager.ChangePostTitleAsync(post.Id, new_title);
+
+        Assert.IsFalse(actual_post);
+        _Post_Repo_Mock.Verify(c => c.GetById(post.Id, It.IsAny<CancellationToken>()));
+        _Post_Repo_Mock.VerifyNoOtherCalls();
+    }
+
+
+    [TestMethod]
+    public async Task ChangePostBodyAsync_Test_Returns_True()
+    {
+        var post = _Posts[0];
+        var new_body = "new title";
+
+        _Post_Repo_Mock.Setup(c => c.GetById(post.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(post);
+        _Post_Repo_Mock.Setup(c => c.Update(post, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(post);
+
+        var actual_post = await _BlogPostManager.ChangePostBodyAsync(post.Id, new_body);
+
+        Assert.IsTrue(actual_post);
+        Assert.AreEqual(post.Body, new_body);
+
+        _Post_Repo_Mock.Verify(c => c.GetById(post.Id, It.IsAny<CancellationToken>()));
+        _Post_Repo_Mock.Verify(c => c.Update(post, It.IsAny<CancellationToken>()));
+        _Post_Repo_Mock.VerifyNoOtherCalls();
+    }
+
+    [TestMethod]
+    public async Task ChangePostBodyAsync_Test_Returns_False_When_Post_Not_Found()
+    {
+        var post_id = 10;
+        var new_body = "new title";
+
+        _Post_Repo_Mock.Setup(c => c.GetById(post_id, It.IsAny<CancellationToken>()));
+
+        var actual_post = await _BlogPostManager.ChangePostTitleAsync(post_id, new_body);
+
+        Assert.IsFalse(actual_post);
+        _Post_Repo_Mock.Verify(c => c.GetById(post_id, It.IsAny<CancellationToken>()));
+        _Post_Repo_Mock.VerifyNoOtherCalls();
+    }
+
+    [TestMethod]
+    public async Task ChangePostTitleAsync_Test_Returns_False_When_Body_is_Null()
+    {
+        var post = _Posts[0];
+        string new_body = null;
+
+        _Post_Repo_Mock.Setup(c => c.GetById(post.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(post);
+
+        var actual_post = await _BlogPostManager.ChangePostTitleAsync(post.Id, new_body);
+
+        Assert.IsFalse(actual_post);
+        _Post_Repo_Mock.Verify(c => c.GetById(post.Id, It.IsAny<CancellationToken>()));
+        _Post_Repo_Mock.VerifyNoOtherCalls();
+    }
     #endregion
 }

--- a/Tests/Thoughts.Services.Tests/RepositoryBlogPostManagerTests.cs
+++ b/Tests/Thoughts.Services.Tests/RepositoryBlogPostManagerTests.cs
@@ -283,7 +283,7 @@ public class RepositoryBlogPostManagerTests
     }
 
     [TestMethod]
-    public async Task GetAllPostsByUserIdSkipTakeAsync_Test_Returns_EmptyEnumerable()
+    public async Task GetAllPostsByUserIdSkipTakeAsync_Test_Returns_EmptyEnumerable_when_Take_eq_0()
     {
         var user_id = "3";
         var skip = 2;
@@ -317,13 +317,13 @@ public class RepositoryBlogPostManagerTests
     }
 
     [TestMethod]
-    public async Task GetAllPostsByUserIdPageAsync_Test_Returns_EmptyPage()
+    public async Task GetAllPostsByUserIdPageAsync_Test_Returns_EmptyPage_when_pageSize_eq_0()
     {
         var user_id = "1";
         var total_count = _Posts.Where(c => c.User.Id == user_id).Count();
 
-        int pageIndex = 0;
-        int pageSize = 3;
+        int pageIndex = 2;
+        int pageSize = 0;
 
         var expected_page = new Page<Post>(Enumerable.Empty<Post>(), pageIndex, pageSize, total_count);
 
@@ -339,17 +339,17 @@ public class RepositoryBlogPostManagerTests
     public async Task GetAllPostsByUserIdPageAsync_Test_Returns_CorrectPage()
     {
         var user_id = "1";
-        var posts = _Posts.Where(p => p.User.Id == user_id);
-        var total_count = posts.Count();
-        int pageIndex = 2;
-        int pageSize = 3;
-
+        int pageIndex = 0;
+        int pageSize = 2;
+        var all_posts = _Posts;
+        var posts = all_posts.Where(p => p.User.Id == user_id).Skip(pageIndex * pageSize).Take(pageSize);
+        var total_count = all_posts.Where(p=>p.User.Id == user_id).Count();
+         
         var expected_page = new Page<Post>(posts, pageIndex, pageSize, total_count);
-
 
         //todo: не понимаю как настроить Mock, тест не проходит
         _Post_Repo_Mock.Setup(c => c.GetAll(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(posts);
+            .ReturnsAsync(all_posts);
 
         var actual_page = await _BlogPostManager.GetAllPostsByUserIdPageAsync(user_id, pageIndex, pageSize);
 

--- a/Tests/Thoughts.Services.Tests/RepositoryBlogPostManagerTests.cs
+++ b/Tests/Thoughts.Services.Tests/RepositoryBlogPostManagerTests.cs
@@ -361,4 +361,71 @@ public class RepositoryBlogPostManagerTests
 
     #endregion
 
+    #region GetById Delete 
+
+    [TestMethod]
+    public async Task GetPostAsync_Test_Returns_Post()
+    {
+        var post_id = 7;
+        var expected_post = _Posts.Single(p => p.Id == post_id);
+
+        _Post_Repo_Mock.Setup(p => p.GetById(post_id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected_post);
+
+        var actual_post = await _BlogPostManager.GetPostAsync(post_id);
+
+        Assert.AreEqual(expected_post, actual_post);
+    }
+
+    [TestMethod] 
+    public async Task DeletePostAsync_Test_Returns_True_if_FindPost()
+    {
+        //Решил дополнительные проверки сделать, сравнивая наборы постов
+
+        var post_id = 1;
+        var posts = _Posts.ToList();
+        var expected_post = _Posts.Single(p => p.Id == post_id);
+        bool expecting_result = posts.Remove(expected_post);
+
+        _Post_Repo_Mock.Setup(p => p.GetById(post_id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected_post);
+        _Post_Repo_Mock.Setup(c => c.DeleteById(post_id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected_post);
+
+        var actual_result = await _BlogPostManager.DeletePostAsync(post_id);
+
+        _Post_Repo_Mock.Setup(c=>c.GetAll(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(posts);
+        var actual_posts = await _BlogPostManager.GetAllPostsAsync();
+
+
+        Assert.AreEqual(expecting_result, actual_result);
+        CollectionAssert.AreNotEqual(_Posts, posts);
+        CollectionAssert.AreEqual(posts, actual_posts.ToArray());
+        _Post_Repo_Mock.Verify(c => c.DeleteById(post_id, It.IsAny<CancellationToken>()));
+        _Post_Repo_Mock.Verify(c => c.GetById(post_id, It.IsAny<CancellationToken>()));
+        _Post_Repo_Mock.Verify(c => c.GetAll(It.IsAny<CancellationToken>()));
+        _Post_Repo_Mock.VerifyNoOtherCalls();
+    }
+
+    [TestMethod]
+    public async Task DeletePostAsync_Test_Returns_False_if_PostNotFound()
+    {
+        var post_id = 8;
+        var posts = _Posts.ToList();
+        var expected_post = _Posts.SingleOrDefault(p => p.Id == post_id);
+        var expecting_result = posts.Remove(expected_post!);
+
+        _Post_Repo_Mock.Setup(p => p.GetById(post_id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected_post!);
+        _Post_Repo_Mock.Setup(c => c.DeleteById(post_id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected_post!);
+
+        var actual_result = await _BlogPostManager.DeletePostAsync(post_id);
+
+        Assert.AreEqual(expecting_result, actual_result);
+    }
+    #endregion
+
+
 }


### PR DESCRIPTION
Продолжение тестирования сервиса RepositoryBlogPostManager, а так же исправление логики работы некоторых методов.
Возникли некоторые сложности в тестах:
CreatePostAsync_Test_Returns_Post_With_newCategory
AssignTagAsync_Test_Returns_True_when_Tag_Is_NewTag
AssignTagAsync_Test_Returns_True_when_Tag_Is_AlreadyAssigned
ChangePostCategoryAsync_Test_Returns_Category_when_Category_is_New
